### PR TITLE
update README.md and add create_namespace flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module "nginx-controller" {
 | Name | Description | Type | Default |  Required |
 |------|-------------|------|---------|:--------:|
 | name  | Name of created helm release | `string` | `ingress-nginx` | no |
-| namespace\_name  | Name of namespace where nginx controller should be deployed | `string` | `kube-system` | no |
+| namespace  | Name of namespace where nginx controller should be deployed | `string` | `kube-system` | no |
 | chart\_version  | HELM Chart Version for controller ( It is not recommended to change )| `string` | `4.0.6` | no |
 | atomic  | If set, installation process purges chart on fail | `bool` | `false` | no |
 | ingress\_class\_name  | IngressClass resource name | `string` | `nginx` | no |

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "helm_release" "application" {
   repository = local.helm_repository
   version    = var.chart_version
   atomic     = var.atomic
+  create_namespace = var.create_namespace
 
   values = [var.disable_heavyweight_metrics ? file("${path.module}/templates/metrics-disable.yaml") : ""]
 

--- a/variables.tf
+++ b/variables.tf
@@ -93,6 +93,12 @@ variable "disable_heavyweight_metrics" {
   default     = false
 }
 
+variable "create_namespace" {
+  type        = bool
+  description = "Create a namespace"
+  default     = false
+}
+
 variable "additional_set" {
   description = "Add additional set for helm"
   default     = []


### PR DESCRIPTION
Adding create_namespace flag to create a custom K8s namespace in case that does not exist.
It's a useful flag for GKE Autopilot since kube-system is managed and not possible to deploy anything in that namespace