### PR TITLE
Added parameters 'wait' and 'timeout'

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,8 @@ module "nginx-controller" {
 | metrics_enabled | Allow exposing metrics for prometheus-operator | `bool` | `false` | no |
 | disable_heavyweight_metrics | Disable some 'heavyweight' or unnecessary metrics | `bool` | `false` | no |
 | additional\_set | Additional sets to Helm | <pre>list(object({<br>    name  = string<br>    value = string<br>    type  = string // Optional<br>  }))</pre> | `[]` |  no |
+| wait | Will wait until all resources are in a ready state" | `bool` | `true` | no |
+| timeout | Time in seconds to wait for any individual kubernetes operation | `number` | `300` | no |
 
 ## Outputs
 | Name | Description |

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,8 @@ resource "helm_release" "application" {
   version    = var.chart_version
   atomic     = var.atomic
   create_namespace = var.create_namespace
+  wait = var.wait
+  timeout = var.timeout
 
   values = [var.disable_heavyweight_metrics ? file("${path.module}/templates/metrics-disable.yaml") : ""]
 

--- a/variables.tf
+++ b/variables.tf
@@ -112,7 +112,7 @@ variable "wait" {
 
 variable "timeout" {
   type        = number
-  description = " Time in seconds to wait for any individual kubernetes operation"
+  description = "Time in seconds to wait for any individual kubernetes operation"
   default     = 300
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -103,3 +103,16 @@ variable "additional_set" {
   description = "Add additional set for helm"
   default     = []
 }
+
+variable "wait" {
+  description = "Will wait until all resources are in a ready state"
+  type        = bool
+  default     = true
+}
+
+variable "timeout" {
+  type        = number
+  description = " Time in seconds to wait for any individual kubernetes operation"
+  default     = 300
+}
+


### PR DESCRIPTION
Mentioned parameters are jus required for succesful deployment to some of specific Kubernetes implementation, like AWS EKS or GCP