### PR TITLE
refactor(variables): explicit type definition of the 'additional_set' var

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -100,8 +100,8 @@ variable "create_namespace" {
 }
 
 variable "additional_set" {
-  description = "Add additional settings for helm"
-  type = list(object({
+  description = "Optional set for additional helm settings"
+  type = set(object({
     name = string
     value = string
     type = string

--- a/variables.tf
+++ b/variables.tf
@@ -100,7 +100,12 @@ variable "create_namespace" {
 }
 
 variable "additional_set" {
-  description = "Add additional set for helm"
+  description = "Add additional settings for helm"
+  type = list(object({
+    name = string
+    value = string
+    type = string
+  }))
   default     = []
 }
 


### PR DESCRIPTION
This is a bit nitpicky, but it's nice to have the type definition more accurate so you can fail faster.

This includes the `type` key in the object's definition, which would not be backwards compatible...so that could be left off if backwards compatibility is desired.  

Otherwise, `type` could be required, as I've written, and then the for loop could be simplified to not set type to `null` if left out.